### PR TITLE
Window support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,8 @@ sudo: false
 language: node_js
 node_js:
   - '0.12'
+os:
+  - osx
+  - windows
 script: "npm run-script coverage"
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,5 @@ sudo: false
 language: node_js
 node_js:
   - '0.12'
-os:
-  - osx
-  - windows
 script: "npm run-script coverage"
 after_script: "cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"

--- a/index.js
+++ b/index.js
@@ -1,21 +1,11 @@
 "use strict";
 
 var exec = require('child_process').exec;
+var commandMaker = process.platform === 'win32' ?
+    require('./make-command-win') : require('./make-command-unix');
 
 module.exports = function(callback, argv) {
-    var command = 'find .';
-    if (typeof argv === 'undefined') {
-        argv = {};
-    }
-    if (typeof argv.dir === 'string') {
-        command += '/' + argv.dir;
-    }
-    if (typeof argv.name === 'string') {
-        command += ' -name "*.'+argv.name+'"';
-    }
-    if (typeof argv.exclude === 'string') {
-        command += ' -not -path "./'+argv.exclude+'/*"';
-    }
+    var command = commandMaker(argv);
 
     exec(command,
         function(error, stdout, stderr) {

--- a/make-command-unix.js
+++ b/make-command-unix.js
@@ -1,0 +1,20 @@
+"use strict";
+
+function makeCommandUnix(argv) {
+    var command = 'find .';
+    if (typeof argv === 'undefined') {
+        argv = {};
+    }
+    if (typeof argv.dir === 'string') {
+        command += '/' + argv.dir;
+    }
+    if (typeof argv.name === 'string') {
+        command += ' -name "*.' + argv.name + '"';
+    }
+    if (typeof argv.exclude === 'string') {
+        command += ' -not -path "./' + argv.exclude + '/*"';
+    }
+    return command;
+}
+
+module.exports = makeCommandUnix;

--- a/make-command-win.js
+++ b/make-command-win.js
@@ -1,0 +1,22 @@
+"use strict";
+
+function makeCommandWin(argv) {
+    var command = 'dir .';
+    if (typeof argv === 'undefined') {
+        argv = {};
+    }
+    if (typeof argv.dir === 'string') {
+        command += '/' + argv.dir;
+    }
+    if (typeof argv.name === 'string') {
+        command += '/*.' + argv.name;
+    }
+    if (typeof argv.exclude === 'string') {
+        console.log('exclude is not yet supported for windows');
+    }
+    command = command.replace(/\//g, '\\');
+    command += ' /b/s';
+    return command;
+}
+
+module.exports = makeCommandWin;

--- a/test.js
+++ b/test.js
@@ -2,9 +2,85 @@
 
 var test = require('tape');
 var find = require('./');
+var makeCommandUnix = require('./make-command-unix');
+var makeCommandWin = require('./make-command-win');
 
 test('should exist', function(t) {
     t.equal(typeof find, 'function');
+    t.equal(typeof makeCommandUnix, 'function');
+    t.equal(typeof makeCommandWin, 'function');
+    t.end();
+});
+
+test('Make Commands', function(t) {
+    t.test('UNIX', function(t) {
+        t.test('should find all as default', function(t) {
+            t.equal(makeCommandUnix(), 'find .');
+            t.end();
+        });
+        t.test('should append specified dir', function(t) {
+            t.equal(makeCommandUnix({
+                dir: 'path/to/dir'
+            }), 'find ./path/to/dir');
+            t.end();
+        });
+        t.test('should append specified name (extention)', function(t) {
+            t.equal(makeCommandUnix({
+                name: 'js'
+            }), 'find . -name "*.js"');
+            t.end();
+        });
+        t.test('should append specified exclude path', function(t) {
+            t.equal(makeCommandUnix({
+                exclude: 'path/to/exclude/dir'
+            }), 'find . -not -path "./path/to/exclude/dir/*"');
+            t.end();
+        });
+        t.test('should append all arguments', function(t) {
+            t.equal(makeCommandUnix({
+                dir: 'path/to/dir',
+                name: 'js',
+                exclude: 'path/to/exclude/dir'
+            }), 'find ./path/to/dir -name "*.js" -not -path "./path/to/exclude/dir/*"');
+            t.end();
+        });
+        t.end();
+    });
+
+    t.test('Windows', function(t) {
+        t.test('should find all as default', function(t) {
+            t.equal(makeCommandWin(), 'dir . /b/s');
+            t.end();
+        });
+        t.test('should append specified dir', function(t) {
+            t.equal(makeCommandWin({
+                dir: 'path/to/dir'
+            }), 'dir .\\path\\to\\dir /b/s');
+            t.end();
+        });
+        t.test('should append specified name (extention)', function(t) {
+            t.equal(makeCommandWin({
+                name: 'js'
+            }), 'dir .\\*.js /b/s');
+            t.end();
+        });
+        // t.test('should append specified exclude path', function(t) {
+        //     t.equal(makeCommandWin({
+        //         exclude: 'path/to/exclude/dir'
+        //     }), 'dir . | findstr /v /i "\.txt$" /b/s');
+        //     t.end();
+        // });
+        t.test('should append all arguments', function(t) {
+            t.equal(makeCommandWin({
+                dir: 'path/to/dir',
+                name: 'js'
+                // exclude: 'path/to/exclude/dir'
+            }), 'dir .\\path\\to\\dir\\*.js /b/s');
+            t.end();
+        });
+        t.end();
+    });
+
     t.end();
 });
 


### PR DESCRIPTION
Command is separated into two modules, one for windows and one for unix.
Note: tests will fail on windows, since it adds C:// path to each file. 
